### PR TITLE
Fixes for close-on-left

### DIFF
--- a/styles/close-on-left.less
+++ b/styles/close-on-left.less
@@ -4,6 +4,11 @@ atom-pane .tab-bar {
     &.active .title, .title {
       padding-left: 28px;
     }
+
+    .title[data-name], .title-icon-tools {
+	padding-left: 28px;
+    }
+
     .close-icon {
       margin-left: 4px;
       margin-right: auto;


### PR DESCRIPTION
fixes to address:
- overlapping text and 'x' when closing a tab
- size of tabs had no maximum, and would span the whole tab bar
