### PR TITLE
Fix indentation and class style for settings tabs

### DIFF
--- a/styles/close-on-left.less
+++ b/styles/close-on-left.less
@@ -5,8 +5,8 @@ atom-pane .tab-bar {
       padding-left: 28px;
     }
 
-    .title[data-name], .title-icon-tools {
-	padding-left: 28px;
+    .title[data-name], .title.icon-tools {
+      padding-left: 28px;
     }
 
     .close-icon {


### PR DESCRIPTION
Realized after updating Atom that the settings tab was still showing an overlapping X on the icon. And that I was using tabs instead of spaces (monstrous!). This fixes those two things for you.
