### PR TITLE
Adding some spacing to the close button when the tab is active

### DIFF
--- a/styles/close-on-left.less
+++ b/styles/close-on-left.less
@@ -1,11 +1,7 @@
 atom-pane .tab-bar {
   .tab {
     // Left align close button and modified indicator in tabs
-    &.active .title, .title {
-      padding-left: 28px;
-    }
-
-    .title[data-name], .title.icon-tools {
+    &.active .title, .title, .title[data-name], .title.icon-tools {
       padding-left: 28px;
     }
 
@@ -13,6 +9,11 @@ atom-pane .tab-bar {
       margin-left: 4px;
       margin-right: auto;
     }
+
+    &.active .close-icon {
+      margin-left: 8px;
+    }
+
     &.modified:not(:hover) .close-icon, .close-icon {
       right: initial;
     }


### PR DESCRIPTION
Currently, the close button is almost touching the "active" tab indicator. These extra few pixels make it look nicer.
