### PR TITLE
Improve on active tab displacement, per theme.

### DIFF
--- a/styles/close-on-left.less
+++ b/styles/close-on-left.less
@@ -9,11 +9,14 @@ atom-pane .tab-bar {
       margin-left: 4px;
       margin-right: auto;
     }
-
-    &.active .close-icon {
-      margin-left: 8px;
+    
+    .theme-one-dark-ui &,
+    .theme-one-light-ui & {
+      &.active .close-icon {
+        margin-left: 8px;
+      }
     }
-
+    
     &.modified:not(:hover) .close-icon, .close-icon {
       right: initial;
     }

--- a/styles/close-on-left.less
+++ b/styles/close-on-left.less
@@ -16,7 +16,7 @@ atom-pane .tab-bar {
         margin-left: 8px;
       }
     }
-    
+
     &.modified:not(:hover) .close-icon, .close-icon {
       right: initial;
     }


### PR DESCRIPTION
Noticed the change I'd made only works for the One themes, but it breaks positioning if you switch to other themes.
I've made it theme specific. To be improved if the change is needed for other themes.
